### PR TITLE
Add bare install-and-run workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup BALROG
         run: |
           pip install balrog-nle
-          pip install -e . -vv
+          pip install -e . -v
           balrog-post-install
 
       - name: Check code quality

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  Test:
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        os: ["ubuntu", "macos"]
+    continue-on-error: false
+    steps:
+      - uses: actions/checkout@v3
+        
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Setup ubuntu prerequisites
+        if: ${{ matrix.os == 'ubuntu' }}
+        run: |
+          sudo apt update
+          sudo apt -y cmake flex bison libgl1 libbz2-dev build-essential libffi-dev
+
+      - name: Setup macos prerequisites
+        if: ${{ matrix.os == 'macos' }}
+        run: |
+          brew install cmake libffi
+          
+      - name: Setup BALROG
+        run: |
+          pip install balrog-nle
+          pip install -e . -vv
+          balrog-post-install
+
+      - name: Check code quality
+        run: |
+          pip install pylint
+          MESSAGE=$(pylint -ry $(git ls-files '*.py') ||:)
+          echo "$MESSAGE"
+
+      - name: Run unit tests with pytest
+        run: |
+          wandb offline
+          pytest tests/test_evaluation.py

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu' }}
         run: |
           sudo apt update
-          sudo apt -y cmake flex bison libgl1 libbz2-dev build-essential libffi-dev
+          sudo apt install -y cmake flex bison libgl1 libbz2-dev build-essential libffi-dev
 
       - name: Setup macos prerequisites
         if: ${{ matrix.os == 'macos' }}


### PR DESCRIPTION
This PR adds an install-and-test workflow for `ubuntu-latest` and `macos-latest`. See here for details on the os images: https://github.com/actions/runner-images.