### PR TITLE
Feedback to invalid actions

### DIFF
--- a/balrog/config/config.yaml
+++ b/balrog/config/config.yaml
@@ -23,6 +23,7 @@ eval:
   save_images: False            # Whether to save images from the environment
   icl_episodes: 1
   icl_dataset: records
+  feedback_on_invalid_action : True       # Whether to provide feedback on invalid actions
 
 client:
   client_name: openai           # LLM client to use (e.g., 'openai', 'gemini', 'claude')

--- a/balrog/evaluator.py
+++ b/balrog/evaluator.py
@@ -323,7 +323,7 @@ class Evaluator:
                 obs["text"]["long_term_context"] = (
                     f"\n\nYour previous output action: '{response.completion}' is not a valid action. Defaulted to action: {action}\n"
                     + obs["text"]["long_term_context"]
-                    if action != response.completion
+                    if (action != response.completion) and (self.config.eval.feedback_on_invalid_action)
                     else obs["text"]["long_term_context"]
                 )
                 action = response.completion

--- a/balrog/evaluator.py
+++ b/balrog/evaluator.py
@@ -321,7 +321,7 @@ class Evaluator:
 
                 # Give feedback on the action (if not valid)
                 obs["text"]["long_term_context"] = (
-                    f"\n\nYour previous output action was not a valid action. Defaulted to action: {action}\n\nObservation:\n"
+                    f"\n\nYour previous output did not contain a valid action. Defaulted to action: {action}\n\nObservation:\n"
                     + obs["text"]["long_term_context"]
                     if (action != response.completion) and (self.config.eval.feedback_on_invalid_action)
                     else obs["text"]["long_term_context"]

--- a/balrog/evaluator.py
+++ b/balrog/evaluator.py
@@ -321,7 +321,7 @@ class Evaluator:
 
                 # Give feedback on the action (if not valid)
                 obs["text"]["long_term_context"] = (
-                    f"\n\nYour previous output action: '{response.completion}' is not a valid action. Defaulted to action: {action}\n"
+                    f"\n\nYour previous output action was not a valid action. Defaulted to action: {action}\n\nObservation:\n"
                     + obs["text"]["long_term_context"]
                     if (action != response.completion) and (self.config.eval.feedback_on_invalid_action)
                     else obs["text"]["long_term_context"]


### PR DESCRIPTION
Change the message to feedback for invalid actions. This would cause problems in CoT models, that would get confused when seeing their thinking replicated in the observation.

Also added the possibility to disable the feedback entirely by using the argument `eval.feedback_on_invalid_action=False`

