### PR TITLE
Reset progression for babyai

### DIFF
--- a/balrog/environments/babyai_text/clean_lang_wrapper.py
+++ b/balrog/environments/babyai_text/clean_lang_wrapper.py
@@ -46,6 +46,7 @@ class BabyAITextCleanLangWrapper(gym.Wrapper):
         obs, info = self.env.reset(**kwargs)
         prompt, image = self.get_prompt(obs, info)
         self._mission = obs["mission"]
+        self.progression = 0.0
         # Following the convention from NetHack Language Wrapper for specifying
         # short term vs long term context here. There is no equivalent long term
         # context like e.g. inventory in BabyAI-Text.


### PR DESCRIPTION
Fixing a bug spotted in #30.

This doesn't affect BALROG's evaluation, as we never actually reset environments after they are finished, and always create an entirely new instance in the evaluator manager, which makes sense in the context of the highly parallel evaluation style that BALROG is supposed to be run in.

This fix will however solve problems for people using BALROG's `make_env` to create BabyAI environments outside of BALROG itself.