### PR TITLE
fix: properly connected client timeout option

### DIFF
--- a/balrog/client.py
+++ b/balrog/client.py
@@ -143,9 +143,9 @@ class OpenAIWrapper(LLMClientWrapper):
         """Initialize the OpenAI client if not already initialized."""
         if not self._initialized:
             if self.client_name.lower() == "vllm":
-                self.client = OpenAI(api_key="EMPTY", base_url=self.base_url)
+                self.client = OpenAI(api_key="EMPTY", base_url=self.base_url, timeout=self.timeout)
             elif self.client_name.lower() == "openai":
-                self.client = OpenAI()
+                self.client = OpenAI(timeout=self.timeout)
             self._initialized = True
 
     def convert_messages(self, messages):
@@ -186,7 +186,6 @@ class OpenAIWrapper(LLMClientWrapper):
                 model=self.model_id,
                 temperature=self.client_kwargs.get("temperature", 0.5),
                 max_tokens=self.client_kwargs.get("max_tokens", 1024),
-                request_timeout=self.timeout,
             )
 
         response = self.execute_with_retries(api_call)

--- a/balrog/client.py
+++ b/balrog/client.py
@@ -186,6 +186,7 @@ class OpenAIWrapper(LLMClientWrapper):
                 model=self.model_id,
                 temperature=self.client_kwargs.get("temperature", 0.5),
                 max_tokens=self.client_kwargs.get("max_tokens", 1024),
+                request_timeout=self.timeout,
             )
 
         response = self.execute_with_retries(api_call)
@@ -275,6 +276,7 @@ class GoogleGenerativeAIWrapper(LLMClientWrapper):
                 response = self.model.generate_content(
                     converted_messages,
                     generation_config=self.generation_config,
+                    request_options={"timeout": self.timeout},
                 )
                 return response
             except Exception as e:
@@ -374,7 +376,7 @@ class ClaudeWrapper(LLMClientWrapper):
     def _initialize_client(self):
         """Initialize the Claude client if not already initialized."""
         if not self._initialized:
-            self.client = Anthropic()
+            self.client = Anthropic(timeout=self.timeout)
             self._initialized = True
 
     def convert_messages(self, messages):

--- a/balrog/config/config.yaml
+++ b/balrog/config/config.yaml
@@ -31,7 +31,7 @@ client:
   generate_kwargs:
     temperature: 0.0            # Sampling temperature; 0.0 makes the output deterministic
     max_tokens: 4096            # Max tokens to generate in the response
-  timeout: 60                   # Timeout for API requests in seconds
+  timeout: 300                  # Timeout for API requests in seconds
   max_retries: 5                # Max number of retries for failed API calls
   delay: 2                      # Exponential backoff factor between retries in seconds
   alternate_roles: False        # Whether the client requires alternating between the agent and the environment


### PR DESCRIPTION
Properly connect timeout argument with OpenAI, Gemini and Claude APIs.
Increase the default timeout to 300s to work with reasoning models taking long to think.