### PR TITLE
Feat: Add support for image-only agents

### DIFF
--- a/balrog/config/config.yaml
+++ b/balrog/config/config.yaml
@@ -1,7 +1,7 @@
 agent: 
   type: naive            # Type of agent to use (e.g., 'naive', 'cot', etc.)
   remember_cot: True     # Whether the agent should remember its reasoning across turns
-  max_history: 16        # Maximum number of previous turns to keep in the dialogue history
+  max_text_history: 16   # Maximum number of text messages to keep in the history
   max_image_history: 0   # Maximum number of images to keep in the history
   max_cot_history: 1     # Maximum number of chain-of-thought steps to keep in history (if using 'cot' type of agent)
   max_icl_history: 1000   # Maximum number of ICL steps to keep in history (if using 'few_shot' type of agent)

--- a/balrog/prompt_builder/__init__.py
+++ b/balrog/prompt_builder/__init__.py
@@ -1,5 +1,6 @@
 from .history import HistoryPromptBuilder
 
+import warnings
 
 def create_prompt_builder(config):
     """
@@ -10,15 +11,24 @@ def create_prompt_builder(config):
     Args:
         config (Config): An object containing configuration settings, which must
             include the following keys:
-            - max_history (int): Maximum number of text history entries to retain.
+            - max_text_history (int): Maximum number of text history entries to retain.
             - max_image_history (int): Maximum number of image history entries to retain.
             - max_cot_history (int): Maximum number of chain-of-thought history entries to retain.
     Returns:
         PromptBuilder: An instance of a prompt builder configured with the specified
             history limits and any additional parameters defined in the config.
     """
+
+    max_history = config.get("max_history", None)
+    if max_history is not None:
+        warnings.warn("The 'max_history' parameter is deprecated. Please use 'max_text_history' instead.")
+    
+    max_text_history = max_history
+    if max_text_history is None:
+        max_text_history = config.max_text_history
+
     return HistoryPromptBuilder(
-        max_history=config.max_history,
+        max_text_history=max_text_history,
         max_image_history=config.max_image_history,
         max_cot_history=config.max_cot_history,
     )

--- a/balrog/prompt_builder/history.py
+++ b/balrog/prompt_builder/history.py
@@ -23,15 +23,16 @@ class HistoryPromptBuilder:
 
     def __init__(
         self,
-        max_history: int = 16,
+        max_text_history: int = 16,
         max_image_history: int = 1,
         system_prompt: Optional[str] = None,
         max_cot_history: int = 1,
     ):
-        self.max_history = max_history
-        self.max_image_history = min(max_image_history, max_history)
+        self.max_text_history = max_text_history
+        self.max_image_history = max_image_history
+        self.max_history = max(max_text_history, max_image_history)
         self.system_prompt = system_prompt
-        self._events = deque(maxlen=max_history * 2)  # Stores observations and actions
+        self._events = deque(maxlen=self.max_history * 2)  # Stores observations and actions
         self._last_short_term_obs = None  # To store the latest short-term observation
         self.previous_reasoning = None
         self.max_cot_history = max_cot_history
@@ -41,7 +42,7 @@ class HistoryPromptBuilder:
         self.system_prompt = instruction
 
     def update_observation(self, obs: dict):
-        """Add an observation to the prompt history, including text and optionall an image."""
+        """Add an observation to the prompt history, which can include text, an image, or both."""
         long_term_context = obs["text"].get("long_term_context", "")
         self._last_short_term_obs = obs["text"].get("short_term_context", "")
         text = long_term_context
@@ -86,7 +87,17 @@ class HistoryPromptBuilder:
         if self.system_prompt and not icl_episodes:
             messages.append(Message(role="user", content=self.system_prompt))
 
-        # Determine which images to include
+        # Determine which text observations to include
+        text_needed = self.max_text_history
+        for event in reversed(self._events):
+            if event["type"] == "observation":
+                if text_needed > 0 and event.get("text") is not None:
+                    event["include_text"] = True
+                    text_needed -= 1
+                else:
+                    event["include_text"] = False
+
+        # Determine which image observations to include
         images_needed = self.max_image_history
         for event in reversed(self._events):
             if event["type"] == "observation":
@@ -108,18 +119,30 @@ class HistoryPromptBuilder:
         # Process events to create messages
         for idx, event in enumerate(self._events):
             if event["type"] == "observation":
-                content = event["text"]
-                image = event.get("image") if event.get("include_image", False) else None
-                image_obs = "\nImage observation provided." if image is not None else ""
+                message_parts = []
+
                 if idx == len(self._events) - 1:
-                    content = "Current Observation:\n" + self._last_short_term_obs + "\n" + event["text"] + image_obs
+                    message_parts.append("Current Observation:")
+                    if self._last_short_term_obs:
+                        message_parts.append(self._last_short_term_obs)
                 else:
-                    content = "Observation:\n" + event["text"] + image_obs
+                    message_parts.append("Observation:")
+
+                if event.get("include_text", False):
+                    message_parts.append(event["text"])
+                    
+                image = None
+                if event.get("include_image", False):
+                    image = event["image"]
+                    message_parts.append("Image observation provided.")
+
+                content = "\n".join(message_parts)
                 message = Message(role="user", content=content, attachment=image)
 
-                # Clean up the temporary flag
-                if "include_image" in event:
-                    del event["include_image"]
+                # Clean up temporary flags
+                for flag in ["include_text", "include_image"]:
+                    if flag in event:
+                        del event[flag]
             elif event["type"] == "action":
                 if event.get("reasoning") is not None:
                     content = "Previous plan:\n" + event["reasoning"]


### PR DESCRIPTION
As discussed in #38, this change enables users to run image-only agents.
I tested the code using a naive GPT4o agent on BabyAI-Pickup, using image-only, text-only, and image + text.

**Potential Issues**
evaluator.py only logs the long_term_context observation.
The "real" observation sent to the LLM is not getting logged.
However, changing this seems to require more significant changes to the architecture.

Also, feedback on invalid actions is stored in the long_term_context.
Setting max_text_history to 0 would hide this feedback from the agent.
It might be sensible to do that using the short_term_context instead, as this one will still be included.
As otherwise information such as the inventory in NetHack would not be passed to the LLM.
