### PR TITLE
Optional additional info in crafter observation

### DIFF
--- a/balrog/config/config.yaml
+++ b/balrog/config/config.yaml
@@ -66,7 +66,11 @@ envs:
     size: [256, 256]            # Image size in Crafter
     reward: True                            
     seed: null                  
-    max_episode_steps: 2000     
+    max_episode_steps: 2000
+    unique_items: True
+    precise_location: False
+    skip_items: []
+    edge_only_items: []
   textworld_kwargs:
     objective: True             
     description: True           

--- a/balrog/config/config.yaml
+++ b/balrog/config/config.yaml
@@ -67,10 +67,10 @@ envs:
     reward: True                            
     seed: null                  
     max_episode_steps: 2000
-    unique_items: True
-    precise_location: False
-    skip_items: []
-    edge_only_items: []
+    unique_items: True # False
+    precise_location: False # True
+    skip_items: [] # ["grass", "sand", "path"]
+    edge_only_items: [] # ["water", "lava"]
   textworld_kwargs:
     objective: True             
     description: True           

--- a/balrog/environments/crafter/crafter_env.py
+++ b/balrog/environments/crafter/crafter_env.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 import crafter
-
 from balrog.environments.crafter import CrafterLanguageWrapper
 from balrog.environments.wrappers import GymV21CompatibilityV0
 
@@ -9,13 +8,25 @@ from balrog.environments.wrappers import GymV21CompatibilityV0
 def make_crafter_env(env_name, task, config, render_mode: Optional[str] = None):
     crafter_kwargs = dict(config.envs.crafter_kwargs)
     max_episode_steps = crafter_kwargs.pop("max_episode_steps", 2)
+    unique_items = crafter_kwargs.pop("unique_items", True)
+    precise_location = crafter_kwargs.pop("precise_location", False)
+    skip_items = crafter_kwargs.pop("skip_items", [])
+    edge_only_items = crafter_kwargs.pop("edge_only_items", [])
 
     for param in ["area", "view", "size"]:
         if param in crafter_kwargs:
             crafter_kwargs[param] = tuple(crafter_kwargs[param])
 
     env = crafter.Env(**crafter_kwargs)
-    env = CrafterLanguageWrapper(env, task, max_episode_steps=max_episode_steps)
+    env = CrafterLanguageWrapper(
+        env,
+        task,
+        max_episode_steps=max_episode_steps,
+        unique_items=unique_items,
+        precise_location=precise_location,
+        skip_items=skip_items,
+        edge_only_items=edge_only_items,
+    )
     env = GymV21CompatibilityV0(env=env, render_mode=render_mode)
 
     return env

--- a/balrog/environments/crafter/env.py
+++ b/balrog/environments/crafter/env.py
@@ -128,9 +128,9 @@ def get_edge_items(semantic, item_idx):
 def describe_env(
     info,
     unique_items=True,
-    precise_location=True,
-    skip_items=["grass", "sand", "path"],
-    edge_only_items=["water"],
+    precise_location=False,
+    skip_items=[],
+    edge_only_items=[],
 ):
     assert info["semantic"][info["player_pos"][0], info["player_pos"][1]] == player_idx
     semantic = info["semantic"][
@@ -233,9 +233,9 @@ def describe_status(info):
 def describe_frame(
     info,
     unique_items=True,
-    precise_location=True,
-    skip_items=["grass", "sand", "path"],
-    edge_only_items=["water"],
+    precise_location=False,
+    skip_items=[],
+    edge_only_items=[],
 ):
     try:
         result = ""
@@ -267,9 +267,9 @@ class CrafterLanguageWrapper(gym.Wrapper):
         task="",
         max_episode_steps=2,
         unique_items=True,
-        precise_location=True,
-        skip_items=["grass", "sand", "path"],
-        edge_only_items=["water"],
+        precise_location=False,
+        skip_items=[],
+        edge_only_items=[],
     ):
         super().__init__(env)
         self.score_tracker = 0

--- a/balrog/environments/crafter/env.py
+++ b/balrog/environments/crafter/env.py
@@ -144,7 +144,7 @@ def describe_env(
     obj_info_list = []
 
     facing = info["player_facing"]
-    max_y, max_x = semantic.shape
+    max_x, max_y = semantic.shape
     target_x = center[0] + facing[0]
     target_y = center[1] + facing[1]
 
@@ -258,8 +258,7 @@ def describe_frame(
 
         return result.strip(), describe_inventory(info)
     except Exception:
-        breakpoint()
-        return "Error, you are out of the map."
+        return "Error, you are out of the map.", describe_inventory(info)
 
 
 class CrafterLanguageWrapper(gym.Wrapper):

--- a/balrog/environments/crafter/env.py
+++ b/balrog/environments/crafter/env.py
@@ -1,4 +1,5 @@
 import itertools
+import re
 from collections import defaultdict
 
 import crafter
@@ -181,18 +182,22 @@ def describe_env(
 
             obj_info_list.append((id_to_item[idx], describe_loc(np.array([0, 0]), np.array([i, j]) - center)))
 
+    def extract_numbers(s):
+        """Extract all numbers from a string."""
+        return [int(num) for num in re.findall(r"\d+", s)]
+
     # filter out items, so we only display closest item of each type
     if unique_items:
         closest_obj_info_list = defaultdict(str)
         for item_name, loc in obj_info_list:
-            loc_dist = int(loc.split(" ")[0])
+            loc_dist = sum(extract_numbers(loc))
             current_dist = (
-                int(closest_obj_info_list[item_name].split(" ")[0])
+                sum(extract_numbers(closest_obj_info_list[item_name]))
                 if closest_obj_info_list[item_name]
                 else float("inf")
             )
 
-            if current_dist > loc_dist:
+            if loc_dist < current_dist:
                 closest_obj_info_list[item_name] = loc
         obj_info_list = [(name, loc) for name, loc in closest_obj_info_list.items()]
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "opencv-python-headless",
         "wandb",
         "pytest",
+        "scipy",
         "crafter",
         "gym==0.23",
         "requests",


### PR DESCRIPTION
### Overview
The current Crafter observation system has two key limitations that impact agent performance:
- Limited objects: `np.unique(semantic)` displays only one object of each type, making it difficult for models to plan effectively in environments with multiple similar objects (e.g., navigating mines surrounded by stones or combat with multiple enemies).
- Misleading directional descriptions: The current format (e.g., "Tree 5 steps north-east") causes LLMs to attempt invalid diagonal movements, as they think that "north-east" is a valid action.


### Added more customization to the crafter language wrapper:
- `unique_items`: Toggle between showing all objects vs. only the closest of each type
- `precise_location`: Choose between explicit directional format vs. diagonal descriptions
    - `True`: "1 step south and 4 steps west"
    - `False`: "5 steps to your south-west"
- `skip_items`: Exclude specified items to reduce observation noise (common: `["grass", "path", "sand"]`)
- `edge_only_items`: Display only edges of large uniform areas (common: `["water", "lava"]`)

### Example language description
The new system can provide richer environmental context:
```
- tree 1 step south and 4 steps west
- tree 3 steps west
- tree 2 steps south and 3 steps west
- tree 1 step south and 2 steps west
- table 3 steps north and 1 step west
- tree 1 step west
- tree 1 step south and 1 step west
- tree 2 steps south
- tree 2 steps south and 3 steps east
- tree 1 step south and 4 steps east
```

Instead of
```
- tree 1 step west
- grass 1 step east
- table 4 steps north-west
```

### Performance Impact
This change improves the performance of the best models. However some weaker models can become worse since this change increases the amount of data in the context. 

### Backward Compatibility
All changes are opt-in. The environment maintains legacy parameters as defaults, ensuring existing implementations continue to work without modification.

